### PR TITLE
Add artifact evidence tests

### DIFF
--- a/ARTIFACT.md
+++ b/ARTIFACT.md
@@ -21,16 +21,16 @@ Rule: if a claim is not marked `closed` here, do not write it in the paper as al
 
 ## Claim matrix
 
-| ID | Claim | Status | Evidence in repo | Current limit |
-| --- | --- | --- | --- | --- |
-| C1 | The artifact proves compile-time structural conformance between producer and contract case classes under tested policies, including nested case classes, sequences, maps, and nested optionality. | `closed` | [src/main/scala/ctdc/ContractsCore.scala](src/main/scala/ctdc/ContractsCore.scala), [src/test/scala/ctdc/SchemaConformsSpec.scala](src/test/scala/ctdc/SchemaConformsSpec.scala) | Coverage is tight for `Exact`, `Backward`, `Forward`, `ExactOrdered`, and `ExactByPosition`. `ExactOrderedCI`, `ExactUnorderedCI`, and `Full` are implemented but not separately asserted here. |
-| C2 | Compile-time failures surface readable, path-rich drift diagnostics instead of a generic missing-given failure. | `closed` | [src/main/scala/ctdc/ContractsCore.scala](src/main/scala/ctdc/ContractsCore.scala), negative checks in [src/test/scala/ctdc/SchemaConformsSpec.scala](src/test/scala/ctdc/SchemaConformsSpec.scala) | The tests assert key snippets, not full golden error text. Message wording can still evolve. |
-| C3 | Spark schema derivation preserves field optionality and nested collection optionality for supported shapes. | `closed` | [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), [src/test/scala/ctdc/SparkSchemaSpec.scala](src/test/scala/ctdc/SparkSchemaSpec.scala) | Supported shape set is still intentionally small: primitives, nested case classes, sequences, maps with atomic keys, and `Option`. |
-| C4 | The runtime pin catches exact-style schema drift, including nested array and map optionality that Spark ignores by default. | `closed` | [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala) | This is a custom comparator that follows Spark name/order semantics and adds the nested optionality check. It is not literally Spark's built-in comparator. |
-| C5 | The sink boundary combines compile-time proof and runtime validation before write. | `closed` | Sink wiring in [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), builder tests in [src/test/scala/ctdc/PipelineBuilderSpec.scala](src/test/scala/ctdc/PipelineBuilderSpec.scala) | The strongest direct evidence is for the typed `PipelineBuilder` path, not every possible caller surface. |
-| C6 | The artifact demonstrates policy-aware runtime behavior beyond the default exact-style path. | `partial` | [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala), [src/test/scala/ctdc/PipelineBuilderSpec.scala](src/test/scala/ctdc/PipelineBuilderSpec.scala) | `ExactByPosition` is covered end-to-end. Other runtime policy variants are implemented but not yet individually tested. |
-| C7 | The artifact proves usability or low overhead in a measurable way. | `open` | None yet | We do not yet have compile-time overhead numbers, runtime overhead numbers, or a user-study-style usability story. |
-| C8 | The artifact proves industrial effectiveness, deployment scale, or incident reduction. | `open` | None in this repo | Those claims must come from separate evidence packs, not from this clean repo alone. |
+| ID | Claim                                                                                                                                                                                             | Status    | Evidence in repo                                                                                                                                                                                                                                                     | Current limit                                                                                                                                                                                   |
+|----|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| C1 | The artifact proves compile-time structural conformance between producer and contract case classes under tested policies, including nested case classes, sequences, maps, and nested optionality. | `closed`  | [src/main/scala/ctdc/ContractsCore.scala](src/main/scala/ctdc/ContractsCore.scala), [src/test/scala/ctdc/SchemaConformsSpec.scala](src/test/scala/ctdc/SchemaConformsSpec.scala)                                                                                     | Coverage is tight for `Exact`, `Backward`, `Forward`, `ExactOrdered`, and `ExactByPosition`. `ExactOrderedCI`, `ExactUnorderedCI`, and `Full` are implemented but not separately asserted here. |
+| C2 | Compile-time failures surface readable, path-rich drift diagnostics instead of a generic missing-given failure.                                                                                   | `closed`  | [src/main/scala/ctdc/ContractsCore.scala](src/main/scala/ctdc/ContractsCore.scala), negative checks in [src/test/scala/ctdc/SchemaConformsSpec.scala](src/test/scala/ctdc/SchemaConformsSpec.scala)                                                                  | The tests assert key snippets, not full golden error text. Message wording can still evolve.                                                                                                    |
+| C3 | Spark schema derivation preserves field optionality and nested collection optionality for supported shapes.                                                                                       | `closed`  | [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), [src/test/scala/ctdc/SparkSchemaSpec.scala](src/test/scala/ctdc/SparkSchemaSpec.scala)                                                                                                   | Supported shape set is still intentionally small: primitives, nested case classes, sequences, maps with atomic keys, and `Option`.                                                              |
+| C4 | The runtime pin catches exact-style schema drift, including nested array and map optionality that Spark ignores by default.                                                                       | `closed`  | [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala)                                                                                                 | This is a custom comparator that follows Spark name/order semantics and adds the nested optionality check. It is not literally Spark's built-in comparator.                                     |
+| C5 | The sink boundary combines compile-time proof and runtime validation before write.                                                                                                                | `closed`  | Sink wiring in [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), builder tests in [src/test/scala/ctdc/PipelineBuilderSpec.scala](src/test/scala/ctdc/PipelineBuilderSpec.scala)                                                           | The strongest direct evidence is for the typed `PipelineBuilder` path, not every possible caller surface.                                                                                       |
+| C6 | The artifact demonstrates policy-aware runtime behavior beyond the default exact-style path.                                                                                                      | `partial` | [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala), [src/test/scala/ctdc/PipelineBuilderSpec.scala](src/test/scala/ctdc/PipelineBuilderSpec.scala) | `ExactByPosition` is covered end-to-end. Other runtime policy variants are implemented but not yet individually tested.                                                                         |
+| C7 | The artifact proves usability or low overhead in a measurable way.                                                                                                                                | `open`    | None yet                                                                                                                                                                                                                                                             | We do not yet have compile-time overhead numbers, runtime overhead numbers, or a user-study-style usability story.                                                                              |
+| C8 | The artifact proves industrial effectiveness, deployment scale, or incident reduction.                                                                                                            | `open`    | None in this repo                                                                                                                                                                                                                                                    | Those claims must come from separate evidence packs, not from this clean repo alone.                                                                                                            |
 
 ## What this repo does not currently prove
 
@@ -45,16 +45,22 @@ Rule: if a claim is not marked `closed` here, do not write it in the paper as al
 
 ### Compile-time proof
 
-- [src/main/scala/ctdc/ContractsCore.scala](src/main/scala/ctdc/ContractsCore.scala): policy model, normalized type shape, macro derivation, and drift rendering
-- [src/test/scala/ctdc/SchemaConformsSpec.scala](src/test/scala/ctdc/SchemaConformsSpec.scala): positive and negative compile-time coverage
-- [src/test/scala/ctdc/PipelineBuilderSpec.scala](src/test/scala/ctdc/PipelineBuilderSpec.scala): builder-surface compile gate at `addSink`
+- [src/main/scala/ctdc/ContractsCore.scala](src/main/scala/ctdc/ContractsCore.scala): policy model, normalized type
+  shape, macro derivation, and drift rendering
+- [src/test/scala/ctdc/SchemaConformsSpec.scala](src/test/scala/ctdc/SchemaConformsSpec.scala): positive and negative
+  compile-time coverage
+- [src/test/scala/ctdc/PipelineBuilderSpec.scala](src/test/scala/ctdc/PipelineBuilderSpec.scala): builder-surface
+  compile gate at `addSink`
 
 ### Runtime proof
 
-- [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala): Spark schema derivation, runtime schema comparator, schema pin, typed sink path
+- [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala): Spark schema derivation, runtime schema
+  comparator, schema pin, typed sink path
 - [src/test/scala/ctdc/SparkSchemaSpec.scala](src/test/scala/ctdc/SparkSchemaSpec.scala): schema derivation checks
-- [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala): runtime drift checks and policy-aware write path
-- [src/test/scala/ctdc/PipelineBuilderSpec.scala](src/test/scala/ctdc/PipelineBuilderSpec.scala): end-to-end green/red sink-boundary checks through `PipelineBuilder`
+- [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala): runtime drift checks and
+  policy-aware write path
+- [src/test/scala/ctdc/PipelineBuilderSpec.scala](src/test/scala/ctdc/PipelineBuilderSpec.scala): end-to-end green/red
+  sink-boundary checks through `PipelineBuilder`
 
 ### Example surface
 
@@ -67,7 +73,8 @@ These are safe summary lines for the current repo state:
 
 - The artifact proves compile-time structural contract conformance for a focused set of Scala 3 case-class schemas.
 - The artifact derives Spark schemas from the same type model and enforces a runtime schema pin.
-- The runtime pin includes a custom check for nested collection optionality, because Spark ignores that drift by default.
+- The runtime pin includes a custom check for nested collection optionality, because Spark ignores that drift by
+  default.
 
 These are not yet safe as proven claims from this repo:
 
@@ -85,5 +92,6 @@ These are not yet safe as proven claims from this repo:
 
 ## Note on FlowForge
 
-`flowforge` is useful as a semantic source and a motivation source, but it is not this artifact.
-Do not treat FlowForge implementation history as proof for claims marked `closed` here unless that evidence is copied into a separate, reviewable pack.
+[`flowforge`](https://github.com/vim89/flowforge) is useful as a semantic source and a motivation source, but it is not this artifact.
+Do not treat FlowForge implementation history as proof for claims marked `closed` here unless that evidence is copied
+into a separate, reviewable pack.

--- a/ARTIFACT.md
+++ b/ARTIFACT.md
@@ -27,8 +27,8 @@ Rule: if a claim is not marked `closed` here, do not write it in the paper as al
 | C2 | Compile-time failures surface readable, path-rich drift diagnostics instead of a generic missing-given failure. | `closed` | [src/main/scala/ctdc/ContractsCore.scala](src/main/scala/ctdc/ContractsCore.scala), negative checks in [src/test/scala/ctdc/SchemaConformsSpec.scala](src/test/scala/ctdc/SchemaConformsSpec.scala) | The tests assert key snippets, not full golden error text. Message wording can still evolve. |
 | C3 | Spark schema derivation preserves field optionality and nested collection optionality for supported shapes. | `closed` | [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), [src/test/scala/ctdc/SparkSchemaSpec.scala](src/test/scala/ctdc/SparkSchemaSpec.scala) | Supported shape set is still intentionally small: primitives, nested case classes, sequences, maps with atomic keys, and `Option`. |
 | C4 | The runtime pin catches exact-style schema drift, including nested array and map optionality that Spark ignores by default. | `closed` | [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala) | This is a custom comparator that follows Spark name/order semantics and adds the nested optionality check. It is not literally Spark's built-in comparator. |
-| C5 | The sink boundary combines compile-time proof and runtime validation before write. | `partial` | Sink wiring in [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), examples in [src/main/scala/ctdc/CtdcPoc.scala](src/main/scala/ctdc/CtdcPoc.scala), policy-aware write check in [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala) | The direct write path is tested, but there is no full end-to-end red/green `PipelineBuilder` test yet. |
-| C6 | The artifact demonstrates policy-aware runtime behavior beyond the default exact-style path. | `partial` | [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), `ExactByPosition` write test in [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala) | `ExactByPosition` is covered. Other runtime policy variants are implemented but not yet individually tested. |
+| C5 | The sink boundary combines compile-time proof and runtime validation before write. | `closed` | Sink wiring in [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), builder tests in [src/test/scala/ctdc/PipelineBuilderSpec.scala](src/test/scala/ctdc/PipelineBuilderSpec.scala) | The strongest direct evidence is for the typed `PipelineBuilder` path, not every possible caller surface. |
+| C6 | The artifact demonstrates policy-aware runtime behavior beyond the default exact-style path. | `partial` | [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala), [src/test/scala/ctdc/PipelineBuilderSpec.scala](src/test/scala/ctdc/PipelineBuilderSpec.scala) | `ExactByPosition` is covered end-to-end. Other runtime policy variants are implemented but not yet individually tested. |
 | C7 | The artifact proves usability or low overhead in a measurable way. | `open` | None yet | We do not yet have compile-time overhead numbers, runtime overhead numbers, or a user-study-style usability story. |
 | C8 | The artifact proves industrial effectiveness, deployment scale, or incident reduction. | `open` | None in this repo | Those claims must come from separate evidence packs, not from this clean repo alone. |
 
@@ -47,12 +47,14 @@ Rule: if a claim is not marked `closed` here, do not write it in the paper as al
 
 - [src/main/scala/ctdc/ContractsCore.scala](src/main/scala/ctdc/ContractsCore.scala): policy model, normalized type shape, macro derivation, and drift rendering
 - [src/test/scala/ctdc/SchemaConformsSpec.scala](src/test/scala/ctdc/SchemaConformsSpec.scala): positive and negative compile-time coverage
+- [src/test/scala/ctdc/PipelineBuilderSpec.scala](src/test/scala/ctdc/PipelineBuilderSpec.scala): builder-surface compile gate at `addSink`
 
 ### Runtime proof
 
 - [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala): Spark schema derivation, runtime schema comparator, schema pin, typed sink path
 - [src/test/scala/ctdc/SparkSchemaSpec.scala](src/test/scala/ctdc/SparkSchemaSpec.scala): schema derivation checks
 - [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala): runtime drift checks and policy-aware write path
+- [src/test/scala/ctdc/PipelineBuilderSpec.scala](src/test/scala/ctdc/PipelineBuilderSpec.scala): end-to-end green/red sink-boundary checks through `PipelineBuilder`
 
 ### Example surface
 
@@ -76,9 +78,9 @@ These are not yet safe as proven claims from this repo:
 
 ## Next evidence to add
 
-1. Automated `PipelineBuilder` red/green tests for compile-time and runtime sink behavior.
-2. A small benchmark for compile/build overhead.
-3. A small benchmark for runtime comparator overhead.
+1. A small benchmark for compile/build overhead.
+2. A small benchmark for runtime comparator overhead.
+3. Individual runtime tests for the remaining non-default policies.
 4. A separate industrial evidence pack outside this repo.
 
 ## Note on FlowForge

--- a/ARTIFACT.md
+++ b/ARTIFACT.md
@@ -1,0 +1,87 @@
+# Artifact evidence matrix
+
+This file is the paper-facing claim ledger for `compile-time-data-contracts`.
+
+Use it before writing or revising the abstract, contributions, evaluation, or artifact section.
+
+Rule: if a claim is not marked `closed` here, do not write it in the paper as already proven by this repo.
+
+## Scope of this artifact
+
+- Clean reference implementation for compile-time structural contract checks on Scala 3 case classes
+- Spark schema derivation and runtime schema pinning
+- Small typed pipeline builder and demo code
+- Paper artifact evidence, not industrial proof
+
+## Status legend
+
+- `closed`: backed by code and direct tests in this repo
+- `partial`: implemented or demonstrated, but not yet covered tightly enough to state as fully proven
+- `open`: not yet proven by this repo
+
+## Claim matrix
+
+| ID | Claim | Status | Evidence in repo | Current limit |
+| --- | --- | --- | --- | --- |
+| C1 | The artifact proves compile-time structural conformance between producer and contract case classes under tested policies, including nested case classes, sequences, maps, and nested optionality. | `closed` | [src/main/scala/ctdc/ContractsCore.scala](src/main/scala/ctdc/ContractsCore.scala), [src/test/scala/ctdc/SchemaConformsSpec.scala](src/test/scala/ctdc/SchemaConformsSpec.scala) | Coverage is tight for `Exact`, `Backward`, `Forward`, `ExactOrdered`, and `ExactByPosition`. `ExactOrderedCI`, `ExactUnorderedCI`, and `Full` are implemented but not separately asserted here. |
+| C2 | Compile-time failures surface readable, path-rich drift diagnostics instead of a generic missing-given failure. | `closed` | [src/main/scala/ctdc/ContractsCore.scala](src/main/scala/ctdc/ContractsCore.scala), negative checks in [src/test/scala/ctdc/SchemaConformsSpec.scala](src/test/scala/ctdc/SchemaConformsSpec.scala) | The tests assert key snippets, not full golden error text. Message wording can still evolve. |
+| C3 | Spark schema derivation preserves field optionality and nested collection optionality for supported shapes. | `closed` | [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), [src/test/scala/ctdc/SparkSchemaSpec.scala](src/test/scala/ctdc/SparkSchemaSpec.scala) | Supported shape set is still intentionally small: primitives, nested case classes, sequences, maps with atomic keys, and `Option`. |
+| C4 | The runtime pin catches exact-style schema drift, including nested array and map optionality that Spark ignores by default. | `closed` | [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala) | This is a custom comparator that follows Spark name/order semantics and adds the nested optionality check. It is not literally Spark's built-in comparator. |
+| C5 | The sink boundary combines compile-time proof and runtime validation before write. | `partial` | Sink wiring in [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), examples in [src/main/scala/ctdc/CtdcPoc.scala](src/main/scala/ctdc/CtdcPoc.scala), policy-aware write check in [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala) | The direct write path is tested, but there is no full end-to-end red/green `PipelineBuilder` test yet. |
+| C6 | The artifact demonstrates policy-aware runtime behavior beyond the default exact-style path. | `partial` | [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala), `ExactByPosition` write test in [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala) | `ExactByPosition` is covered. Other runtime policy variants are implemented but not yet individually tested. |
+| C7 | The artifact proves usability or low overhead in a measurable way. | `open` | None yet | We do not yet have compile-time overhead numbers, runtime overhead numbers, or a user-study-style usability story. |
+| C8 | The artifact proves industrial effectiveness, deployment scale, or incident reduction. | `open` | None in this repo | Those claims must come from separate evidence packs, not from this clean repo alone. |
+
+## What this repo does not currently prove
+
+- Semantic contracts such as ranges, domain constraints, or business rules
+- Temporal or cross-record constraints
+- Runtime subset semantics for `Backward` and `Forward`
+- External schema registry integration
+- Benchmark-based claims about compile time or runtime overhead
+- Industrial metrics, deployment counts, or incident reduction claims
+
+## Evidence inventory
+
+### Compile-time proof
+
+- [src/main/scala/ctdc/ContractsCore.scala](src/main/scala/ctdc/ContractsCore.scala): policy model, normalized type shape, macro derivation, and drift rendering
+- [src/test/scala/ctdc/SchemaConformsSpec.scala](src/test/scala/ctdc/SchemaConformsSpec.scala): positive and negative compile-time coverage
+
+### Runtime proof
+
+- [src/main/scala/ctdc/SparkCore.scala](src/main/scala/ctdc/SparkCore.scala): Spark schema derivation, runtime schema comparator, schema pin, typed sink path
+- [src/test/scala/ctdc/SparkSchemaSpec.scala](src/test/scala/ctdc/SparkSchemaSpec.scala): schema derivation checks
+- [src/test/scala/ctdc/SparkRuntimeSpec.scala](src/test/scala/ctdc/SparkRuntimeSpec.scala): runtime drift checks and policy-aware write path
+
+### Example surface
+
+- [src/main/scala/ctdc/CtdcPoc.scala](src/main/scala/ctdc/CtdcPoc.scala): compile-only and pipeline demo code
+- [README.md](README.md): public artifact description and quick-start examples
+
+## Paper-safe wording
+
+These are safe summary lines for the current repo state:
+
+- The artifact proves compile-time structural contract conformance for a focused set of Scala 3 case-class schemas.
+- The artifact derives Spark schemas from the same type model and enforces a runtime schema pin.
+- The runtime pin includes a custom check for nested collection optionality, because Spark ignores that drift by default.
+
+These are not yet safe as proven claims from this repo:
+
+- The approach has low compile-time or runtime overhead.
+- The approach improves developer productivity in measured terms.
+- The approach reduces incidents in production.
+- The approach is validated across multiple real teams or systems.
+
+## Next evidence to add
+
+1. Automated `PipelineBuilder` red/green tests for compile-time and runtime sink behavior.
+2. A small benchmark for compile/build overhead.
+3. A small benchmark for runtime comparator overhead.
+4. A separate industrial evidence pack outside this repo.
+
+## Note on FlowForge
+
+`flowforge` is useful as a semantic source and a motivation source, but it is not this artifact.
+Do not treat FlowForge implementation history as proof for claims marked `closed` here unless that evidence is copied into a separate, reviewable pack.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 **Pipelines don’t even compile if producer/contract schemas drift.**
 This article proves it with Scala 3 macros (compile-time evidence) and Spark structural checks (runtime pin).
 
+For paper work, use [ARTIFACT.md](ARTIFACT.md) as the canonical claim-to-evidence map.
+If a claim is not marked `closed` there, do not state it as already proven by this repo.
+
 ## What this is
 
 A tiny but complete proof-of-concept:

--- a/src/test/scala/ctdc/PipelineBuilderSpec.scala
+++ b/src/test/scala/ctdc/PipelineBuilderSpec.scala
@@ -1,0 +1,126 @@
+package ctdc
+
+import ctdc.ContractsCore.SchemaPolicy
+import ctdc.SparkCore.{PipelineBuilder, TypedSink, TypedSource}
+import munit.FunSuite
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.functions.*
+
+import java.nio.file.Files
+
+import scala.compiletime.testing.typeCheckErrors
+
+class PipelineBuilderSpec extends FunSuite:
+
+  private lazy val spark: SparkSession =
+    SparkSession
+      .builder()
+      .appName("ctdc-pipeline-builder-spec")
+      .master("local[1]")
+      .config("spark.ui.enabled", "false")
+      .config("spark.sql.shuffle.partitions", "1")
+      .getOrCreate()
+
+  override def afterAll(): Unit =
+    try spark.stop()
+    finally super.afterAll()
+
+  private inline def assertTypeFails(inline code: String, expectedSnippets: String*): Unit =
+    val errors = typeCheckErrors(code)
+    assert(
+      errors.nonEmpty,
+      clues("Expected code to fail typechecking, but it compiled successfully.")
+    )
+    val rendered = errors.map(_.message).mkString("\n---\n")
+    expectedSnippets.foreach { snippet =>
+      assert(
+        rendered.contains(snippet),
+        clues(s"Expected error output to contain: $snippet", rendered)
+      )
+    }
+
+  private def writeCustomerCsv(): String =
+    val dir = Files.createTempDirectory("ctdc-builder-in")
+    val csv = dir.resolve("customer.csv")
+    Files.writeString(
+      csv,
+      """id,email,age,segment
+        |1,a@b.com,21,S
+        |2,b@c.com,,L
+        |""".stripMargin
+    )
+    dir.toString
+
+  test("PipelineBuilder addSink surfaces compile-time contract drift") {
+    assertTypeFails(
+      """
+        import ctdc.ContractsCore.SchemaPolicy
+        import ctdc.SparkCore.*
+
+        final case class Contract(id: Long, email: String)
+        final case class Producer(id: Long, email: String, segment: String)
+
+        val src  = TypedSource[Producer]("csv", "/tmp/in", Map("header" -> "true"))
+        val sink = TypedSink[Contract]("/tmp/out")
+
+        PipelineBuilder[Contract]("exact-extra")
+          .addSource(src)
+          .noTransform
+          .addSink[Contract, SchemaPolicy.Exact.type](sink)
+      """,
+      "parameter ev1 of method addSink",
+      "SchemaConforms[Producer, Contract"
+    )
+  }
+
+  test("PipelineBuilder writes when declared transform output and runtime output both match the sink policy") {
+    import spark.implicits.*
+
+    final case class CustomerContract(id: Long, email: String, age: Option[Int] = None)
+    final case class CustomerProducer(id: Long, email: String, age: Option[Int], segment: String)
+    final case class CustomerNext(id: Long, email: String, age: Option[Int])
+
+    val src  = TypedSource[CustomerProducer]("csv", writeCustomerCsv(), Map("header" -> "true"))
+    val out  = Files.createTempDirectory("ctdc-builder-out").toString
+    val sink = TypedSink[CustomerContract](out)
+
+    val plan =
+      PipelineBuilder[CustomerContract]("pipeline-green")
+        .addSource(src)
+        .transformAs[CustomerNext]("drop segment")(_.select($"id", $"email", $"age"))
+        .addSink[CustomerContract, SchemaPolicy.ExactByPosition.type](sink)
+        .build
+
+    val result  = plan(spark)
+    val written = spark.read.parquet(out)
+
+    assertEquals(result.columns.toList, List("id", "email", "age"))
+    assertEquals(result.count(), 2L)
+    assertEquals(written.columns.toList, List("id", "email", "age"))
+    assertEquals(written.count(), 2L)
+  }
+
+  test("PipelineBuilder runtime sink pin rejects a transform that violates the chosen sink policy") {
+    import spark.implicits.*
+
+    final case class CustomerContract(id: Long, email: String, age: Option[Int] = None)
+    final case class CustomerProducer(id: Long, email: String, age: Option[Int], segment: String)
+    final case class CustomerNext(id: Long, email: String, age: Option[Int])
+
+    val src  = TypedSource[CustomerProducer]("csv", writeCustomerCsv(), Map("header" -> "true"))
+    val out  = Files.createTempDirectory("ctdc-builder-bad-out").toString
+    val sink = TypedSink[CustomerContract](out)
+
+    val plan =
+      PipelineBuilder[CustomerContract]("pipeline-red")
+        .addSource(src)
+        .transformAs[CustomerNext]("reorder columns")(_.select($"email", $"id", $"age"))
+        .addSink[CustomerContract, SchemaPolicy.ExactByPosition.type](sink)
+        .build
+
+    val ex = intercept[IllegalArgumentException] {
+      plan(spark)
+    }
+
+    assert(clue(ex.getMessage).contains("Runtime schema mismatch"))
+  }


### PR DESCRIPTION
## What changed
- added PipelineBuilder tests for compile-time and runtime sink checks
- updated ARTIFACT.md to mark the sink-boundary claim as closed
- listed the new test file in the evidence inventory

## Check
- sbt test