### PR TITLE
Add final arxiv prep helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ docs/internals/
 
 # local Overleaf binding
 paper/.olcli.json
+.olauth
+paper/.olauth
+paper/main.bbl
 
 # generated manuscript bundles
 paper/dist/

--- a/paper/README.md
+++ b/paper/README.md
@@ -20,6 +20,7 @@ npx -y @aloth/olcli sync paper
 npx -y @aloth/olcli push paper --all
 npx -y @aloth/olcli pdf paper -o /tmp/paper.pdf
 npx -y @aloth/olcli output bbl --project paper -o paper/output.bbl
+node paper/scripts/fetch-overleaf-bbl.mjs
 paper/scripts/build-arxiv-bundle.sh
 ```
 
@@ -32,7 +33,7 @@ paper/scripts/build-arxiv-bundle.sh
 - The scaffold is synced to the Overleaf project `paper`
 - Remote Overleaf compilation succeeds and PDF download works via `olcli pdf`
 - `olcli output log` works and confirms the manuscript reads `./output.bbl` during compile
-- `olcli output bbl` is still returning a false `not found` in this setup; treat that as a CLI issue, not a manuscript issue
+- `olcli output bbl` is still flaky in this setup, so `paper/scripts/fetch-overleaf-bbl.mjs` is the reliable local fallback
 - detailed submission and release prep notes are kept in local-only internal docs
 
 ## Next edits

--- a/paper/scripts/build-arxiv-bundle.sh
+++ b/paper/scripts/build-arxiv-bundle.sh
@@ -9,6 +9,9 @@ mkdir -p "$out_dir/sections" "$out_dir/figures"
 
 cp "$root_dir/main.tex" "$out_dir/"
 cp "$root_dir/references.bib" "$out_dir/"
+if [ -f "$root_dir/main.bbl" ]; then
+  cp "$root_dir/main.bbl" "$out_dir/"
+fi
 cp "$root_dir/sections/"*.tex "$out_dir/sections/"
 cp "$root_dir/figures/"*.png "$out_dir/figures/"
 

--- a/paper/scripts/fetch-overleaf-bbl.mjs
+++ b/paper/scripts/fetch-overleaf-bbl.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const paperDir = resolve(__dirname, '..');
+const projectMetaPath = join(paperDir, '.olcli.json');
+const defaultOutputPath = join(paperDir, 'main.bbl');
+const baseUrl = process.env.OVERLEAF_BASE_URL || 'https://www.overleaf.com';
+const cookieName = process.env.OVERLEAF_COOKIE_NAME || 'overleaf_session2';
+
+function parseCookieValue(raw) {
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  if (!trimmed.includes('=')) return trimmed;
+  const parts = trimmed.split(';').map(p => p.trim());
+  const named = parts.find(p => p.startsWith(`${cookieName}=`));
+  if (named) return named.slice(cookieName.length + 1);
+  return '';
+}
+
+function getSessionCookie() {
+  if (process.env.OVERLEAF_SESSION) return process.env.OVERLEAF_SESSION.trim();
+
+  const candidates = [
+    join(process.cwd(), '.olauth'),
+    join(paperDir, '.olauth')
+  ];
+
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    const parsed = parseCookieValue(readFileSync(candidate, 'utf8'));
+    if (parsed) return parsed;
+  }
+
+  throw new Error(
+    'No Overleaf session found. Set OVERLEAF_SESSION or create a local .olauth file.'
+  );
+}
+
+function extractCsrf(html) {
+  const patterns = [
+    /<meta[^>]+name=["']ol-csrfToken["'][^>]+content=["']([^"']+)["']/i,
+    /<input[^>]+name=["']_csrf["'][^>]+value=["']([^"']+)["']/i,
+    /csrfToken["']?\s*[:=]\s*["']([^"']+)["']/i
+  ];
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match) return match[1];
+  }
+
+  throw new Error('Could not find Overleaf CSRF token.');
+}
+
+function mergeSetCookies(cookieJar, response) {
+  const setCookies = response.headers.getSetCookie?.() || [];
+  for (const setCookie of setCookies) {
+    const match = setCookie.match(/^([^=]+)=([^;]+)/);
+    if (match) cookieJar[match[1]] = match[2];
+  }
+}
+
+function cookieHeader(cookieJar) {
+  return Object.entries(cookieJar)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ');
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function main() {
+  if (!existsSync(projectMetaPath)) {
+    throw new Error(`Missing ${projectMetaPath}`);
+  }
+
+  const projectMeta = JSON.parse(readFileSync(projectMetaPath, 'utf8'));
+  const projectId = projectMeta.projectId;
+  if (!projectId) {
+    throw new Error(`No projectId found in ${projectMetaPath}`);
+  }
+
+  const sessionCookie = getSessionCookie();
+  const cookieJar = { [cookieName]: sessionCookie };
+  const projectPageResponse = await fetch(`${baseUrl}/project`, {
+    headers: {
+      Cookie: cookieHeader(cookieJar),
+      'User-Agent': 'fetch-overleaf-bbl/1.0'
+    }
+  });
+  if (!projectPageResponse.ok) {
+    throw new Error(`Failed to load Overleaf project page: ${projectPageResponse.status}`);
+  }
+  mergeSetCookies(cookieJar, projectPageResponse);
+  const projectPageHtml = await projectPageResponse.text();
+  const csrf = extractCsrf(projectPageHtml);
+
+  let bblUrl = null;
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    const compileResponse = await fetch(`${baseUrl}/project/${projectId}/compile?enable_pdf_caching=true`, {
+      method: 'POST',
+      headers: {
+        Cookie: cookieHeader(cookieJar),
+        'Content-Type': 'application/json',
+        'User-Agent': 'fetch-overleaf-bbl/1.0',
+        'X-Csrf-Token': csrf
+      },
+      body: JSON.stringify({
+        rootDoc_id: null,
+        draft: false,
+        check: 'silent',
+        incrementalCompilesEnabled: true
+      })
+    });
+    if (!compileResponse.ok) {
+      throw new Error(`Compile request failed: ${compileResponse.status}`);
+    }
+    mergeSetCookies(cookieJar, compileResponse);
+    const compileData = await compileResponse.json();
+    const outputFiles = compileData.outputFiles || [];
+    const bbl = outputFiles.find(file => file.type === 'bbl');
+    if (bbl?.url) {
+      bblUrl = `${baseUrl}${bbl.url}`;
+      break;
+    }
+    await sleep(attempt * 1000);
+  }
+
+  if (!bblUrl) {
+    throw new Error('Could not find output.bbl after compile retries.');
+  }
+
+  const bblResponse = await fetch(bblUrl, {
+    headers: {
+      Cookie: cookieHeader(cookieJar),
+      'User-Agent': 'fetch-overleaf-bbl/1.0'
+    }
+  });
+  if (!bblResponse.ok) {
+    throw new Error(`Failed to download output.bbl: ${bblResponse.status}`);
+  }
+  const outputPath = process.argv[2] ? resolve(process.argv[2]) : defaultOutputPath;
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, Buffer.from(await bblResponse.arrayBuffer()));
+  console.log(`Saved ${outputPath}`);
+}
+
+main().catch(error => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a local helper to fetch main.bbl from Overleaf
- include main.bbl in the arXiv bundle when present
- ignore local Overleaf auth and generated bbl files

## Verification
- fetched paper/main.bbl locally from Overleaf
- rebuilt paper/dist/arxiv/ with main.bbl included
